### PR TITLE
feat: upgrade TypeScript to 5.7.2 and update related type packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"remark-math": "^5.1.1",
 		"remark-parse": "^10.0.1",
 		"remark-rehype": "^10.1.0",
-		"typescript": "^4.2.4"
+		"typescript": "^5.7.2"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.17.8",
@@ -65,9 +65,9 @@
 		"@types/gtag.js": "^0.0.8",
 		"@types/jest": "^26.0.23",
 		"@types/jsdom": "^16.2.14",
-		"@types/node": "^15.6.0",
-		"@types/react": "^17.0.6",
-		"@types/react-dom": "^17.0.5",
+		"@types/node": "^22.0.0",
+		"@types/react": "^18.3.0",
+		"@types/react-dom": "^18.3.0",
 		"autoprefixer": "10.4.0",
 		"babel-loader": "^8.2.3",
 		"esbuild": "^0.17.18",


### PR DESCRIPTION
Closes #12

This PR upgrades TypeScript from 4.2.4 to 5.7.2 and updates related type definition packages:

- typescript: 4.2.4 → 5.7.2
- @types/node: 15.6.0 → 22.0.0
- @types/react: 17.0.6 → 18.3.0
- @types/react-dom: 17.0.5 → 18.3.0

Generated with [Claude Code](https://claude.ai/code)