### PR TITLE
Fix OGP image URL protocol

### DIFF
--- a/src/lib/amazon.ts
+++ b/src/lib/amazon.ts
@@ -7,7 +7,7 @@ const imageSizes = [
   'LZZZZZZZ' // 大    500 × 500
 ] as const
 
-export type ImageSize = typeof imageSizes
+export type ImageSize = typeof imageSizes[number]
 
 const asinRegex = /[^0-9A-Z]([0-9A-Z]{10})([^0-9A-Z]|$)/
 

--- a/src/lib/getOgp.ts
+++ b/src/lib/getOgp.ts
@@ -16,7 +16,7 @@ const trimTitle = (title: string) => title.trim()
 const getImageUrl = (imageUrl: string, url: string) => {
   if (imageUrl.charAt(0) !== '/') return imageUrl
   const parsed = new URL(url)
-  return `https//${parsed.hostname}${imageUrl}`
+  return `https://${parsed.hostname}${imageUrl}`
 }
 
 type HasImageURL = {


### PR DESCRIPTION
## Summary
- fix incorrect protocol string when building absolute image URLs

## Testing
- `yarn lint` *(fails: package missing in lockfile)*
- `yarn typecheck` *(fails: package missing in lockfile)*
- `yarn test` *(fails: package missing in lockfile)*

resolve #19

------
https://chatgpt.com/codex/tasks/task_e_68418727e1788327918d006ac688f41a