### PR TITLE
feat: upgrade TypeScript from 4.2.4 to 5.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"remark-math": "^5.1.1",
 		"remark-parse": "^10.0.1",
 		"remark-rehype": "^10.1.0",
-		"typescript": "^4.2.4"
+		"typescript": "^5.8.3"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.17.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11283,10 +11283,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@^4.2.4:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+typescript@^5.8.3:
+  version "5.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.3.tgz#92f8a3e5e3cf497356f4178c34cd65a7f5e8440e"
+  integrity sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==
 
 ufo@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
Updated TypeScript to the latest 5.x version (5.8.3) and updated yarn.lock with new dependency resolutions.

## Changes
- Updated TypeScript from ^4.2.4 to ^5.8.3 in package.json
- Updated yarn.lock with new dependency resolutions
- Verified TypeScript compilation works correctly

Closes #15

Generated with [Claude Code](https://claude.ai/code)