### PR TITLE
fix: コンテナの最大幅をヘッダーと揃えて本文の左偏りを修正

### DIFF
--- a/src/components/server/headless/container.astro
+++ b/src/components/server/headless/container.astro
@@ -1,3 +1,3 @@
 ---
 ---
-<div class="container mx-auto px-4 md:px-5"><slot /></div>
+<div class="mx-auto w-full max-w-7xl px-4 md:px-5"><slot /></div>

--- a/src/components/server/headless/container.tsx
+++ b/src/components/server/headless/container.tsx
@@ -5,7 +5,7 @@ type Props = {
 }
 
 const Container: FunctionComponent<Props> = ({ children }) => {
-  return <div className="container mx-auto px-4 md:px-5">{children}</div>
+  return <div className="mx-auto w-full max-w-7xl px-4 md:px-5">{children}</div>
 }
 
 export default Container

--- a/src/components/server/post/markdown-styles.module.css
+++ b/src/components/server/post/markdown-styles.module.css
@@ -1,5 +1,6 @@
 .markdown {
-  @apply prose prose-invert tracking-wide max-w-full;
+  @apply prose prose-invert tracking-wide;
+  max-width: 100%;
 
   /* Headings */
   @apply prose-headings:mb-4 prose-headings:border-b prose-headings:border-background-light prose-headings:pb-1 prose-headings:font-normal prose-headings:leading-snug prose-headings:text-background-light;

--- a/src/components/server/post/post-by-slug.astro
+++ b/src/components/server/post/post-by-slug.astro
@@ -22,13 +22,13 @@ const diff = differenceInYears(new Date(), parseISO(post.date))
       <Warning text={`この記事は最終更新日から${diff}年以上が経過しています。`} />
     )}
     <PostMetadata post={post} variant="mobile" />
-    <div class="grid grid-cols-1 md:grid-cols-4">
-      <div class="md:col-span-3">
+    <div class="flex flex-col lg:flex-row lg:gap-8">
+      <div class="min-w-0 flex-1">
         <PostBody content={post.content} />
       </div>
-      <div class="hidden md:block md:col-span-1 md:h-full">
+      <aside class="hidden lg:block lg:w-56 lg:shrink-0">
         <PostMetadata post={post} variant="desktop" />
-      </div>
+      </aside>
     </div>
   </Container>
 </article>

--- a/src/components/server/post/post-metadata.astro
+++ b/src/components/server/post/post-metadata.astro
@@ -11,7 +11,7 @@ interface Props {
 const { post, variant } = Astro.props
 ---
 {variant === 'mobile' ? (
-  <div class="mt-4 grid grid-cols-1 gap-y-4 md:hidden">
+  <div class="mt-4 grid grid-cols-1 gap-y-4 lg:hidden">
     {post.series && (
       <div class="">
         <Series {...post.series} />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -27,7 +27,7 @@ const morePosts = allPosts.slice(1)
     />
   )}
   {morePosts.length > 0 && (
-    <div class="container mx-auto p-5">
+    <div class="mx-auto w-full max-w-7xl p-5">
       <MoreStories posts={morePosts} />
     </div>
   )}


### PR DESCRIPTION
Tailwindの`container`クラスは2xlブレイクポイント(1536px以上)で最大幅が
1536pxに拡張されるが、ヘッダーは`max-w-7xl`(1280px)で固定されていた。
広い画面でコンテナの左端がヘッダーより128px左にはみ出し、本文が左に
偏って見える原因となっていた。

`container`クラスを`max-w-7xl`に統一し、ヘッダーとコンテンツの幅を合わせた。

https://claude.ai/code/session_01V7TfMj7Cvr9xWNr4mwf3MM